### PR TITLE
feat(skills): add invoice-processing, doc-organize, email-triage skills

### DIFF
--- a/.claude/skills/doc-organize/SKILL.md
+++ b/.claude/skills/doc-organize/SKILL.md
@@ -1,0 +1,69 @@
+---
+name: doc-organize
+description: Read document content → classify by type → apply YYYY-MM-DD taxonomy naming → move to organized subdirs → generate manifest. Use when organizing chaotic document folders.
+compatibility: Designed for Claude Code
+metadata:
+  argument-hint: [source-dir] [output-dir]
+  allowed-tools: Read, Write, Glob, Bash
+  mcp-servers: [filesystem]
+---
+
+# Document Organization
+
+**Source**: $ARGUMENTS (defaults: `./inbox/` → `./archive/`)
+
+Deterministic pipeline: read content → classify → rename → move → manifest.
+
+## Document Types
+
+| Type | Subdir | Naming pattern |
+|------|--------|----------------|
+| invoice | `invoices/` | `YYYY-MM-DD_invoice_<vendor>.ext` |
+| receipt | `receipts/` | `YYYY-MM-DD_receipt_<vendor>.ext` |
+| contract | `contracts/` | `YYYY-MM-DD_contract_<counterparty>.ext` |
+| correspondence | `correspondence/` | `YYYY-MM-DD_<sender>_<subject-slug>.ext` |
+| report | `reports/` | `YYYY-MM-DD_report_<title-slug>.ext` |
+| unknown | `unsorted/` | original filename (unchanged) |
+
+## Workflow
+
+1. **Discover files** — glob `$SOURCE_DIR` recursively for all non-hidden files
+2. **Read content** — read each file (not just filename) to determine type and extract:
+   - `type` — classify using Document Types table above
+   - `date` — find most specific date in content; normalize to YYYY-MM-DD; fallback to file mtime
+   - `key_name` — vendor / counterparty / sender (lowercase, spaces → hyphens, max 30 chars)
+3. **Generate target path** — apply naming pattern from table; truncate slug to 40 chars
+4. **Detect conflicts** — if target path already exists, append `_2`, `_3`, etc.
+5. **Move files** — move `$SOURCE_DIR/<file>` → `$OUTPUT_DIR/<subdir>/<new-name>`
+6. **Write manifest** — create `$OUTPUT_DIR/manifest.csv` with columns:
+   `Original | NewPath | Type | Date | KeyName | Action`
+   - `Action`: `moved` | `conflict-renamed` | `skipped-unreadable`
+7. **Print summary** — count per type, count skipped
+
+## Input Contract
+
+```
+$SOURCE_DIR/
+  **/*    — any document files (PDF, DOCX, TXT, images, etc.)
+```
+
+## Output Contract
+
+```
+$OUTPUT_DIR/
+  invoices/        — invoice documents
+  receipts/        — receipt documents
+  contracts/       — contract documents
+  correspondence/  — letters, emails
+  reports/         — report documents
+  unsorted/        — unclassified files
+  manifest.csv     — full audit trail of all moves
+stdout             — summary counts per type
+```
+
+## Constraints
+
+- Do NOT delete source files — move only (manifest allows reversal)
+- Do NOT rename files in `unsorted/` — preserve originals for human review
+- If a file cannot be read, move to `unsorted/` with `skipped-unreadable` in manifest
+- Idempotent: running twice on same source does not duplicate files (conflict detection handles it)

--- a/.claude/skills/email-triage/SKILL.md
+++ b/.claude/skills/email-triage/SKILL.md
@@ -1,0 +1,67 @@
+---
+name: email-triage
+description: Read email threads → categorize by urgency → draft responses for review → flag priorities → identify newsletters for unsubscribe. Use when processing an email backlog.
+compatibility: Designed for Claude Code
+metadata:
+  argument-hint: [mailbox-export-dir] [output-dir]
+  allowed-tools: Read, Write, Glob, Bash
+  mcp-servers: [filesystem, google-workspace, m365]
+---
+
+# Email Triage
+
+**Source**: $ARGUMENTS (defaults: `./emails/` → `./triage/`)
+
+Deterministic pipeline: read threads → categorize → draft → output review package.
+
+## Urgency Categories
+
+| Priority | Label | Criteria |
+|----------|-------|----------|
+| P1 | `urgent` | Deadline within 24h, financial/legal matter, executive sender |
+| P2 | `action-needed` | Requires response or decision, no immediate deadline |
+| P3 | `fyi` | Informational only, no action required |
+| P4 | `newsletter` | Marketing, subscription, automated digest |
+| P5 | `spam` | Unsolicited, phishing indicators, irrelevant |
+
+## Workflow
+
+1. **Discover emails** — read `$SOURCE_DIR` for `.eml`, `.mbox`, or `.json` export files
+2. **Parse threads** — group by thread/subject; for each thread extract:
+   - `subject`, `sender`, `date` (most recent message), `body` (latest + context)
+3. **Categorize** — assign priority label using Urgency Categories table
+4. **Draft responses** — for P1 and P2 threads only:
+   - Write a concise draft response (≤150 words)
+   - Mark draft as `[DRAFT — REVIEW BEFORE SENDING]`
+   - Do NOT include personal sign-off — leave placeholder `[Your name]`
+5. **Flag newsletters** — for P4 threads, extract unsubscribe link if present
+6. **Write outputs**:
+   - `$OUTPUT_DIR/triage-summary.md` — all threads sorted by priority with drafts inline
+   - `$OUTPUT_DIR/urgent.md` — P1 threads only (quick action view)
+   - `$OUTPUT_DIR/unsubscribe-list.md` — P4 newsletter unsubscribe links
+7. **Print summary** — count per priority label
+
+## Input Contract
+
+```
+$SOURCE_DIR/
+  *.eml | *.mbox | *.json   — exported email files or mailbox dumps
+```
+
+## Output Contract
+
+```
+$OUTPUT_DIR/
+  triage-summary.md     — full categorized list with response drafts
+  urgent.md             — P1-only quick action list
+  unsubscribe-list.md   — newsletter unsubscribe links
+stdout                  — counts: P1=N, P2=N, P3=N, P4=N, P5=N
+```
+
+## Constraints
+
+- Do NOT send any emails — output drafts only for human review
+- Do NOT store email content outside `$OUTPUT_DIR`
+- Draft responses for P1/P2 only; P3–P5 get categorization only
+- If thread body is empty or unreadable, categorize as P3 with note `[body-unavailable]`
+- Phishing indicators (mismatched sender domains, suspicious links) → P5 + note `[phishing-suspected]`

--- a/.claude/skills/invoice-processing/SKILL.md
+++ b/.claude/skills/invoice-processing/SKILL.md
@@ -1,0 +1,56 @@
+---
+name: invoice-processing
+description: OCR and extract invoice/receipt data → validate → output organized spreadsheet. Use when processing invoices, receipts, or expense documents.
+compatibility: Designed for Claude Code
+metadata:
+  argument-hint: [source-dir] [output-file.xlsx]
+  allowed-tools: Read, Write, Glob, Bash
+  mcp-servers: [filesystem, xero, quickbooks]
+---
+
+# Invoice Processing
+
+**Source**: $ARGUMENTS (defaults: `./inbox/` → `./output/invoices.xlsx`)
+
+Deterministic pipeline: scan documents → extract fields → validate → write spreadsheet.
+
+## Workflow
+
+1. **Discover documents** — glob `$SOURCE_DIR` for `*.pdf`, `*.png`, `*.jpg`, `*.jpeg`
+2. **Extract fields** — for each document read/OCR and extract:
+   - `vendor` (company name)
+   - `date` (normalize to YYYY-MM-DD)
+   - `amount` (numeric, preserve currency symbol)
+   - `invoice_number` (as printed; `null` if absent)
+   - `category` (auto-classify: travel, office, software, meals, other)
+3. **Validate** — flag anomalies before writing:
+   - Duplicate `invoice_number` across documents
+   - `amount` = 0 or negative
+   - `date` more than 90 days in the past or any future date
+   - Missing required fields (`vendor`, `date`, `amount`)
+4. **Write spreadsheet** — create `$OUTPUT_FILE` with columns:
+   `File | Vendor | Date | Amount | Currency | Invoice# | Category | Flag`
+   - Sort by `Date` ascending
+   - Highlight flagged rows (add `[FLAG: reason]` in `Flag` column)
+5. **Print summary** — total count, total amount per currency, flagged count
+
+## Input Contract
+
+```
+$SOURCE_DIR/
+  *.pdf | *.png | *.jpg | *.jpeg   — invoice/receipt files
+```
+
+## Output Contract
+
+```
+$OUTPUT_FILE.xlsx    — populated spreadsheet, sorted by date
+stdout               — summary: N docs processed, N flagged, totals by currency
+```
+
+## Constraints
+
+- Do NOT move or delete source files
+- Do NOT push to accounting system — output only (human reviews before upload)
+- If a document cannot be read, add row with `[UNREADABLE]` flag and continue
+- Currency: preserve original; do not convert


### PR DESCRIPTION
## Summary

- Add `invoice-processing` skill: OCR receipts/PDFs → extract vendor/date/amount/invoice# → validate (duplicates, anomalies) → output organized XLSX
- Add `doc-organize` skill: content-aware classification → YYYY-MM-DD taxonomy naming → move to typed subdirs → generate audit manifest
- Add `email-triage` skill: categorize threads by urgency (P1–P5) → draft P1/P2 responses for review → identify newsletters for unsubscribe

## Test plan

- [ ] Invoke `/invoice-processing inbox/ output/invoices.xlsx` with sample PDFs — verify XLSX columns and flags
- [ ] Invoke `/doc-organize inbox/ archive/` with mixed docs — verify subdir structure and manifest.csv
- [ ] Invoke `/email-triage emails/ triage/` with exported .eml files — verify triage-summary.md and urgent.md

Generated with Claude <noreply@anthropic.com>