### PR TITLE
feat(mcp): add productivity, documents, crm, and accounting MCP configs

### DIFF
--- a/mcp/README.md
+++ b/mcp/README.md
@@ -11,9 +11,41 @@ Pre-configured MCP server definitions for business APIs. Copy relevant configs t
 | Config | Servers | Domain |
 |--------|---------|--------|
 | `accounting.json` | Stripe, Xero, QuickBooks, FreshBooks | Payments + bookkeeping |
-| `productivity.json` | Google Workspace, Slack, Notion | Email + communication |
-| `crm.json` | HubSpot, Salesforce | Client management |
-| `documents.json` | Word MCP, Excel MCP, DocCreator | File manipulation |
+| `productivity.json` | Google Workspace (Gmail, Calendar, Drive, Docs, Sheets) | Email + communication |
+| `crm.json` | HubSpot, Salesforce (via Composio) | Client management |
+| `documents.json` | Office-Word-MCP-Server, excel-mcp-server, mcp-server-doccreator | File manipulation |
+
+## Auth Requirements
+
+### accounting.json
+
+| Server | Auth | Env Vars |
+|--------|------|----------|
+| Stripe | API key | `STRIPE_API_KEY` |
+| Xero | OAuth 2.0 | `XERO_CLIENT_ID`, `XERO_CLIENT_SECRET` |
+| QuickBooks | OAuth 2.0 | `QB_CLIENT_ID`, `QB_CLIENT_SECRET`, `QB_REALM_ID` |
+| FreshBooks | OAuth 2.0 | `FRESHBOOKS_CLIENT_ID`, `FRESHBOOKS_CLIENT_SECRET` |
+
+### productivity.json
+
+| Server | Auth | Env Vars / Setup |
+|--------|------|-----------------|
+| Google Workspace | OAuth 2.0 | `GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET`, `GOOGLE_REFRESH_TOKEN` — covers Gmail, Calendar, Drive, Docs, Sheets, Slides, Forms, Tasks, Contacts, Chat. Source: [taylorwilsdon/google_workspace_mcp](https://github.com/taylorwilsdon/google_workspace_mcp) |
+
+### crm.json
+
+| Server | Auth | Env Vars / Setup |
+|--------|------|-----------------|
+| HubSpot | OAuth 2.0 | `HUBSPOT_PORTAL_ID` — requires HubSpot CLI v7.60.0+. Run `hs mcp setup` to complete OAuth flow. Currently read-only. |
+| Salesforce | API key (Composio) | `COMPOSIO_MCP_URL`, `COMPOSIO_API_KEY` — full CRUD via Composio hub. See [composio.dev](https://composio.dev/toolkits/salesforce/framework/claude-code) |
+
+### documents.json
+
+| Server | Auth | Env Vars / Notes |
+|--------|------|-----------------|
+| Office-Word-MCP-Server | None | No auth required. Source: [GongRzhe/Office-Word-MCP-Server](https://github.com/GongRzhe/Office-Word-MCP-Server) |
+| excel-mcp-server | None | `EXCEL_MCP_PAGING_CELLS_LIMIT` controls paging (default 4000). Source: [negokaz/excel-mcp-server](https://github.com/negokaz/excel-mcp-server) |
+| mcp-server-doccreator | None | Multi-format: PDF, DOCX, PPTX, XLSX. Source: [Git-Fg/mcp-server-doccreator](https://github.com/Git-Fg/mcp-server-doccreator) |
 
 ## Usage
 

--- a/mcp/accounting.json
+++ b/mcp/accounting.json
@@ -1,0 +1,39 @@
+{
+  "mcpServers": {
+    "stripe": {
+      "type": "http",
+      "url": "https://mcp.stripe.com",
+      "env": {
+        "STRIPE_API_KEY": "${STRIPE_API_KEY}"
+      }
+    },
+    "xero": {
+      "type": "stdio",
+      "command": "npx",
+      "args": ["-y", "@xeroapi/xero-mcp-server"],
+      "env": {
+        "XERO_CLIENT_ID": "${XERO_CLIENT_ID}",
+        "XERO_CLIENT_SECRET": "${XERO_CLIENT_SECRET}"
+      }
+    },
+    "quickbooks": {
+      "type": "stdio",
+      "command": "npx",
+      "args": ["-y", "quickbooks-mcp"],
+      "env": {
+        "QB_CLIENT_ID": "${QB_CLIENT_ID}",
+        "QB_CLIENT_SECRET": "${QB_CLIENT_SECRET}",
+        "QB_REALM_ID": "${QB_REALM_ID}"
+      }
+    },
+    "freshbooks": {
+      "type": "stdio",
+      "command": "npx",
+      "args": ["-y", "freshbooks-mcp"],
+      "env": {
+        "FRESHBOOKS_CLIENT_ID": "${FRESHBOOKS_CLIENT_ID}",
+        "FRESHBOOKS_CLIENT_SECRET": "${FRESHBOOKS_CLIENT_SECRET}"
+      }
+    }
+  }
+}

--- a/mcp/crm.json
+++ b/mcp/crm.json
@@ -1,0 +1,19 @@
+{
+  "mcpServers": {
+    "hubspot": {
+      "type": "stdio",
+      "command": "hs",
+      "args": ["mcp", "start"],
+      "env": {
+        "HUBSPOT_PORTAL_ID": "${HUBSPOT_PORTAL_ID}"
+      }
+    },
+    "salesforce": {
+      "type": "http",
+      "url": "${COMPOSIO_MCP_URL}",
+      "headers": {
+        "X-API-Key": "${COMPOSIO_API_KEY}"
+      }
+    }
+  }
+}

--- a/mcp/documents.json
+++ b/mcp/documents.json
@@ -1,0 +1,24 @@
+{
+  "mcpServers": {
+    "office-word": {
+      "type": "stdio",
+      "command": "uvx",
+      "args": ["office-word-mcp-server"],
+      "env": {}
+    },
+    "excel": {
+      "type": "stdio",
+      "command": "npx",
+      "args": ["-y", "@negokaz/excel-mcp-server"],
+      "env": {
+        "EXCEL_MCP_PAGING_CELLS_LIMIT": "4000"
+      }
+    },
+    "doccreator": {
+      "type": "stdio",
+      "command": "uvx",
+      "args": ["mcp-server-doccreator"],
+      "env": {}
+    }
+  }
+}

--- a/mcp/productivity.json
+++ b/mcp/productivity.json
@@ -1,0 +1,14 @@
+{
+  "mcpServers": {
+    "google-workspace": {
+      "type": "stdio",
+      "command": "uvx",
+      "args": ["google-workspace-mcp"],
+      "env": {
+        "GOOGLE_CLIENT_ID": "${GOOGLE_CLIENT_ID}",
+        "GOOGLE_CLIENT_SECRET": "${GOOGLE_CLIENT_SECRET}",
+        "GOOGLE_REFRESH_TOKEN": "${GOOGLE_REFRESH_TOKEN}"
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Add `mcp/accounting.json`: Stripe (official HTTP MCP), Xero, QuickBooks, FreshBooks
- Add `mcp/productivity.json`: Google Workspace MCP covering Gmail, Calendar, Drive, Docs, Sheets, Slides, Forms, Tasks, Contacts, Chat
- Add `mcp/documents.json`: Office-Word-MCP-Server (DOCX), excel-mcp-server (XLSX), mcp-server-doccreator (multi-format PDF/DOCX/PPTX/XLSX)
- Add `mcp/crm.json`: HubSpot (official CLI, read-only), Salesforce (full CRUD via Composio)
- Update `mcp/README.md`: expand Available Configs table + add Auth Requirements section with env vars per server

All configs use CC `.mcp.json` format (`mcpServers` object). Sources verified from `CC-business-api-integrations.md` and `CC-office-document-skills.md`.

## Test plan

- [ ] Verify JSON files parse correctly (`python -m json.tool mcp/*.json`)
- [ ] Confirm `mcpServers` keys match CC `.mcp.json` format
- [ ] Review auth env vars match each provider's documented requirements

Generated with Claude <noreply@anthropic.com>