### PR TITLE
chore(makefile): add setup_gh_auth target with durable GPG signing config

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .SILENT:
 .ONESHELL:
-.PHONY: help setup_all generate_tasks start_workspace
+.PHONY: help setup_all setup_gh_auth generate_tasks start_workspace
 .DEFAULT_GOAL := help
 
 
@@ -8,6 +8,12 @@
 
 
 setup_all: generate_tasks start_workspace  ## Run full setup (generate tasks, open workspace)
+
+setup_gh_auth:  ## Configure gh as git credential helper + durable GPG signing config
+	if command -v gh > /dev/null 2>&1; then gh auth setup-git; \
+	else echo "gh cli not installed. skipping auth."; fi
+	git config --global commit.gpgsign true
+	git config --global gpg.format openpgp
 
 
 # MARK: WORKSPACE


### PR DESCRIPTION
## Summary

Stacked on #14. Mirrors polyforge#52 / fixes upstream polyforge#48 inherited
by office-forge through the #14 refactor.

Adds a `setup_gh_auth` target to the Makefile:

```makefile
setup_gh_auth:
	if command -v gh > /dev/null 2>&1; then gh auth setup-git; \
	else echo "gh cli not installed. skipping auth."; fi
	git config --global commit.gpgsign true
	git config --global gpg.format openpgp
```

Idempotent — safe to run when values are already set.

## Office-domain divergence vs polyforge

Polyforge appended two lines to an existing `setup_gh_auth` target.
Office-forge's #14 Makefile is workspace-focused and has no such target,
so this PR introduces it from scratch — bundling `gh auth setup-git` +
GPG config in one recipe. Same outcome (durable signing in
sibling-cloned/toggle-after-creation cases), different starting point.

Not wired into `setup_all` (which is workspace-focused: `generate_tasks
start_workspace`). Operator runs `make setup_gh_auth` explicitly.

## Authority chain

This is **mechanism**. The corresponding **policy** doc lives in
qte77/qte77 (`docs/gpg-signing.md`). Mechanism here, policy there, per
the team-OS authority split.

## Test plan

- [ ] `make setup_gh_auth` succeeds without error
- [ ] After running, `git config --global commit.gpgsign` returns `true`
- [ ] After running, `git config --global gpg.format` returns `openpgp`
- [ ] Re-running is idempotent (no error)
- [ ] CodeFactor / CI green

## Merge order

Stacked on #14. Merge #14 first; this PR will then auto-rebase onto main
(or change-base via `gh pr edit --base main`).

Closes #18

Generated with Claude <noreply@anthropic.com>