### PR TITLE
docs(pat-scoping): per-repo PAT + branch protection + push-protection checklist

### DIFF
--- a/docs/pat-scoping.md
+++ b/docs/pat-scoping.md
@@ -1,0 +1,96 @@
+# PAT Scoping & Hardening
+
+Manual hardening checklist for repositories that receive cross-project
+agent writes from office-forge-orchestrator. Every step is a GitHub UI
+action — automation isn't appropriate because credentials and protection
+rules are operator-controlled by design.
+
+## Per-repo fine-grained PAT
+
+Use one fine-grained PAT per logical scope (per-repo or per-org), not
+one classic PAT for everything. Classic PATs grant broad scopes;
+fine-grained PATs scope to specific repositories with minimum
+permissions.
+
+**When to create:**
+
+- Cross-project agent automation that writes (issue/PR/file changes)
+- CI jobs that push or open PRs
+- Anything that needs scopes the Codespaces-injected `GITHUB_TOKEN`
+  doesn't carry
+
+**Where to create:**
+GitHub → Settings → Developer settings → Personal access tokens →
+**Fine-grained tokens** → Generate new token.
+
+**Minimum recommended permissions:**
+
+| Permission | Access | Why |
+|---|---|---|
+| Contents | Read & write | `git push`, `git pull` |
+| Pull requests | Read & write | `gh pr create`, review/merge |
+| Issues | Read & write | issue creation, labels, comments |
+| Metadata | Read | implicit dependency for all of the above |
+| Workflows | Read & write | only if the PAT touches `.github/workflows/*` |
+
+**Repo selection:** specific repos only. Never "All repositories" or
+"Public repositories."
+
+**Expiration:** 90 days max. Rotation policy below.
+
+**Storage:** the PAT goes into `gh secret set GH_PAT --user --repos
+<owner>/<repo>` — never committed.
+
+## Branch protection on `main`
+
+For every repo that receives PR-bot writes, enable branch protection
+on the default branch:
+
+GitHub → Settings → Branches → Add rule (target: `main`):
+
+- [ ] **Require a pull request before merging** — direct pushes blocked
+- [ ] **Require linear history** — no merge commits, squash or rebase only
+- [ ] **Require signed commits** — ties into the GPG signing policy
+      (qte77/qte77/docs/gpg-signing.md); the PR can't merge without
+      verified signatures on every commit
+- [ ] **Block force pushes** — keep history immutable
+- [ ] **Block deletions** — `main` can't be deleted via API
+- [ ] **Do not allow bypassing the above settings** — applies to admins
+      too; prevents accidental override
+
+## Secret-scanning push protection
+
+GitHub → Settings → Code security and analysis:
+
+- [ ] **Secret scanning** — On
+- [ ] **Push protection** — On (blocks pushes that contain detected
+      secrets before they hit the remote)
+
+This catches the most common credential-leak failure mode: an agent
+or human accidentally pasting a token into a commit. Free for public
+repos; included with GitHub Advanced Security for private.
+
+**Office-domain note:** office-forge-orchestrator manages MCP server
+configs (`mcp/`) that may reference external business-API credentials
+(accounting, CRM, email, productivity). When secret scanning catches a
+push, audit *all* MCP config touch points before re-pushing — these
+credentials carry the same compromise blast radius as a Git PAT.
+
+## Rotation cadence
+
+- **Quarterly review** — list all fine-grained PATs (Settings →
+  Developer settings → Personal access tokens → Fine-grained tokens),
+  prune unused ones, regenerate any that are over 60 days old
+- **Immediate rotation** on any of:
+  - Suspected compromise (logs show unauthorized actions)
+  - Codespace recovered from a public branch
+  - Departure of any operator who held the PAT
+  - **MCP credential exposure** — rotate the PAT *and* the MCP server
+    credential as a pair when either is suspected compromised
+- **Document rotations** in the repo's CHANGELOG or a private notes
+  channel — not in a commit, never in code
+
+## See also
+
+- `qte77/qte77/docs/gpg-signing.md` — signed-commit policy that
+  branch protection's "require signed commits" rule enforces

--- a/docs/pat-scoping.md
+++ b/docs/pat-scoping.md
@@ -85,8 +85,9 @@ credentials carry the same compromise blast radius as a Git PAT.
   - Suspected compromise (logs show unauthorized actions)
   - Codespace recovered from a public branch
   - Departure of any operator who held the PAT
-  - **MCP credential exposure** — rotate the PAT *and* the MCP server
-    credential as a pair when either is suspected compromised
+  - **Business-API credential exposure** — rotate the PAT *and* the
+    affected business-API credential (Stripe, HubSpot, Xero, etc.) as
+    a pair when either is suspected compromised
 - **Document rotations** in the repo's CHANGELOG or a private notes
   channel — not in a commit, never in code
 


### PR DESCRIPTION
## Summary

Stacked on #14. Mirrors polyforge#54.

New `docs/pat-scoping.md` — manual hardening checklist:

- **Per-repo fine-grained PAT** with permissions table (Contents R/W,
  PR R/W, Issues R/W, Metadata R; Workflows R/W only if needed),
  90-day expiration
- **Branch protection on `main`** — require PR, linear history, signed
  commits (ties to qte77/qte77 GPG policy), block force-push, block
  deletions, no admin bypass
- **Secret-scanning push protection** — on for every repo
- **Quarterly rotation cadence** + immediate-rotation triggers

## Office-domain divergence vs polyforge

- Secret-scanning section calls out the **business-API credentials**
  (Stripe, HubSpot, Xero, QuickBooks, FreshBooks, Google Workspace,
  Composio) consumed by `mcp/*.json` configs as a paired risk surface
  alongside PATs — same compromise blast radius as a Git PAT
- Rotation triggers add a **business-API credential exposure** entry:
  rotate PAT *and* affected business-API credential together when
  either is suspected compromised
- "See also" trimmed: polyforge's links to `codespaces.md` and
  `cross-repo-setup.md` dropped because office-forge has neither file
  yet (deferred to docs scaffolding pass — tracked in #17)

Note: framing reads "business-API credentials consumed by the MCP
servers", not "MCP credentials" — the credentials authenticate
against external APIs; MCP is just the transport layer.

## Test plan

- [ ] Render `docs/pat-scoping.md` on GitHub — sections + permissions
      table render cleanly
- [ ] Cross-link to `qte77/qte77/docs/gpg-signing.md` resolves
- [ ] Checklist items map 1:1 to actions in #19
- [ ] CodeFactor / CI green

## Merge order

Stacked on #14. Merge #14 first; this PR will then auto-rebase onto
main (or change-base via `gh pr edit --base main`).

Closes #19

Generated with Claude <noreply@anthropic.com>