### PR TITLE
docs(codespaces): scaffold codespaces.md + GH_PAT precedence convention

### DIFF
--- a/docs/codespaces.md
+++ b/docs/codespaces.md
@@ -1,0 +1,78 @@
+# Codespaces
+
+Operator notes for running office-forge-orchestrator inside GitHub
+Codespaces. This doc currently covers GitHub token precedence only —
+devcontainer lifecycle, secrets management, and MCP credential
+injection sections will land as the corresponding wiring matures (see
+the Status section at the bottom).
+
+## Token precedence — what wins when multiple are set
+
+When more than one credential source is present, both `gh` and `git`
+follow this precedence:
+
+1. **`GITHUB_TOKEN`** env var — wins outright if set
+2. **`GH_TOKEN`** env var — wins over hosts.yml
+3. **hosts.yml OAuth token** — used only when neither env var is set
+
+The trap: `GITHUB_TOKEN` or `GH_TOKEN` set in your environment
+**silently shadows** the hosts.yml OAuth token. If the env-var token has
+narrower scope than the OAuth one, cross-repo writes can fail with `403`
+even though `gh auth status` looks healthy.
+
+### Convention: `GH_PAT` as the named override
+
+Standardize on a single named env var, `GH_PAT`, as the *intentional*
+override. The intended `containerEnv` wiring in
+`.devcontainer/devcontainer.json` is:
+
+```json
+"containerEnv": {
+    "GH_PAT": "${localEnv:GH_PAT}",
+    "GH_TOKEN": "${localEnv:GH_PAT}"
+}
+```
+
+When you want write access through a fine-grained PAT, set `GH_PAT` in
+your local environment. Everything else flows from there. No need to
+set `GITHUB_TOKEN` or `GH_TOKEN` directly.
+
+> **Status note:** the office-forge devcontainer does not yet ship the
+> `containerEnv` block above — it has only `onCreateCommand: make
+> setup_all` and dotfiles wiring. The convention is documented here
+> first; the wiring will follow in a separate PR.
+
+### Escape hatch: explicitly drop env precedence
+
+When env-var precedence must be dropped (e.g. third-party install
+scripts that fight your token), prefix the command with explicit
+clearing:
+
+```bash
+GITHUB_TOKEN= GH_TOKEN= some-command
+```
+
+This is the canonical pattern for any automation that must run under a
+different token (or no token at all).
+
+## See also
+
+- [`docs/pat-scoping.md`](pat-scoping.md) — fine-grained PAT scopes,
+  branch protection, push-protection checklist
+- `qte77/qte77/docs/gpg-signing.md` — signed-commit policy that pairs
+  with the PAT-scoping branch-protection rule
+
+## Status
+
+This document currently covers token precedence only. The following
+sections are intentionally deferred until the corresponding wiring
+exists or scope expands:
+
+- **Devcontainer lifecycle** (`onCreateCommand`, `postAttachCommand`)
+- **Rebuild / Management** (`gh codespace rebuild|list|stop|ssh|delete`)
+- **Secrets** (Codespaces user-secret scoping for `GH_PAT` and MCP
+  credentials)
+- **Token scopes** (capability table for `GITHUB_TOKEN` vs `GH_PAT`)
+- **MCP credential injection** (the env vars referenced by `mcp/*.json`
+  configs — accounting, CRM, documents)
+- **Ports and Forwarding**

--- a/docs/codespaces.md
+++ b/docs/codespaces.md
@@ -70,9 +70,10 @@ exists or scope expands:
 
 - **Devcontainer lifecycle** (`onCreateCommand`, `postAttachCommand`)
 - **Rebuild / Management** (`gh codespace rebuild|list|stop|ssh|delete`)
-- **Secrets** (Codespaces user-secret scoping for `GH_PAT` and MCP
-  credentials)
+- **Secrets** (Codespaces user-secret scoping for `GH_PAT` and
+  business-API credentials consumed by the MCP servers)
 - **Token scopes** (capability table for `GITHUB_TOKEN` vs `GH_PAT`)
-- **MCP credential injection** (the env vars referenced by `mcp/*.json`
-  configs — accounting, CRM, documents)
+- **Business-API credential injection** (the env vars referenced by
+  `mcp/*.json` configs — Stripe, HubSpot, Xero, QuickBooks,
+  FreshBooks, Google Workspace, Composio)
 - **Ports and Forwarding**


### PR DESCRIPTION
## Summary

Stacked on #14. Mirrors polyforge#53.

Scaffolds a minimal `docs/codespaces.md` (~78 lines) containing the
GH_PAT precedence convention from polyforge#53 plus a Status section
listing deferred content. Office-forge has neither the file nor the
parent `docs/` dir on main, and #14 doesn't add either, so this PR is
scaffold + section in one.

## Office-domain divergences vs polyforge mirror

1. **Did not port the full polyforge codespaces.md.** Polyforge's
   Devcontainer Lifecycle (multi-root + `postAttachCommand`), Token
   scopes table, and Secrets section all describe `containerEnv`
   wiring that office-forge's `.devcontainer/devcontainer.json` does
   NOT yet have. Porting them would document behavior that doesn't
   exist — flagged in the doc's status note. Wiring is a separate
   concern (tracked in #23).

2. **Dropped `setup_rtk` reference** from the precedence section's
   escape-hatch example. Office-forge has no `setup_rtk` Makefile
   target. Replaced with generic `GITHUB_TOKEN= GH_TOKEN= some-command`
   pattern.

3. **Dropped `cross-repo-setup.md` cross-link.** That doc lives in
   polyforge's own `docs/`, not in office-forge or qte77/qte77.
   Replaced "See also" with links to `docs/pat-scoping.md` (PR #21)
   and qte77/qte77 GPG policy.

4. **Business-API credentials deferred.** Office-forge's `mcp/*.json`
   configs reference 14 credential env vars (Stripe, HubSpot, Xero,
   QuickBooks, FreshBooks, Google Workspace, Composio). They do NOT
   interact with GH_TOKEN/GITHUB_TOKEN precedence — they're
   independent. Per scope, business-API credential coverage stays out
   of #17 and is tracked in #24. Note: the credentials authenticate
   against external APIs; MCP is just the transport that consumes
   them.

## Test plan

- [ ] Render `docs/codespaces.md` on GitHub — section structure clean,
      code blocks render
- [ ] Cross-link to `docs/pat-scoping.md` (lands via PR #21) resolves
      after the stack merges
- [ ] Cross-link to `qte77/qte77/docs/gpg-signing.md` resolves
- [ ] Status section accurately reflects deferred scope
- [ ] CodeFactor / CI green

## Merge order

Stacked on #14. Merge #14 first; this PR will then auto-rebase onto
main (or change-base via `gh pr edit --base main`).

## Follow-ups (already filed)

- #23 — wire `containerEnv` in devcontainer.json
- #24 — document business-API credential injection via Codespaces secrets
- #25 — port generic Codespaces sections (lifecycle, management, etc.)

Closes #17

Generated with Claude <noreply@anthropic.com>