### PR TITLE
chore(lint): bump SHA pin and apply inference fixes

### DIFF
--- a/.claude/skills/doc-organize/SKILL.md
+++ b/.claude/skills/doc-organize/SKILL.md
@@ -42,14 +42,14 @@ Deterministic pipeline: read content → classify → rename → move → manife
 
 ## Input Contract
 
-```
+```text
 $SOURCE_DIR/
   **/*    — any document files (PDF, DOCX, TXT, images, etc.)
 ```
 
 ## Output Contract
 
-```
+```text
 $OUTPUT_DIR/
   invoices/        — invoice documents
   receipts/        — receipt documents

--- a/.claude/skills/email-triage/SKILL.md
+++ b/.claude/skills/email-triage/SKILL.md
@@ -43,14 +43,14 @@ Deterministic pipeline: read threads → categorize → draft → output review 
 
 ## Input Contract
 
-```
+```text
 $SOURCE_DIR/
   *.eml | *.mbox | *.json   — exported email files or mailbox dumps
 ```
 
 ## Output Contract
 
-```
+```text
 $OUTPUT_DIR/
   triage-summary.md     — full categorized list with response drafts
   urgent.md             — P1-only quick action list

--- a/.claude/skills/invoice-processing/SKILL.md
+++ b/.claude/skills/invoice-processing/SKILL.md
@@ -36,14 +36,14 @@ Deterministic pipeline: scan documents → extract fields → validate → write
 
 ## Input Contract
 
-```
+```text
 $SOURCE_DIR/
   *.pdf | *.png | *.jpg | *.jpeg   — invoice/receipt files
 ```
 
 ## Output Contract
 
-```
+```text
 $OUTPUT_FILE.xlsx    — populated spreadsheet, sorted by date
 stdout               — summary: N docs processed, N flagged, totals by currency
 ```

--- a/.github/workflows/lint-md-links.yml
+++ b/.github/workflows/lint-md-links.yml
@@ -13,5 +13,5 @@ permissions:
 
 jobs:
   lint:
-    uses: qte77/.github/.github/workflows/lint-md-links.yml@5dfff1f73ac7241ef37b6103e04d2a8373ff68a4  # 2026-04-27
+    uses: qte77/.github/.github/workflows/lint-md-links.yml@55ea1a9910b7dfe02853437345fd76c009cb858f  # 2026-04-27
 ...

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Execution happens through Claude Code (or compatible agents). Office-forge sets 
 
 # Interactive: start CC in a project context with office skills loaded
 cd projects/client-acme/ && claude
-```
+```text
 
 ## Project Structure
 
@@ -46,7 +46,7 @@ office-forge/
 ├── mcp/                       # MCP server configs for business APIs
 ├── templates/                 # Project templates (new client, quarterly close, etc.)
 └── config/                    # Environment and credential setup
-```
+```bash
 
 ## Recurring Tasks (/loop)
 
@@ -79,7 +79,7 @@ Start a loop session in any project:
 cd projects/client-acme/ && claude
 # Then in CC:
 /loop 1h check correspondence/ for client messages and summarize action items
-```
+```bash
 
 ## Skills (Deterministic Workflows)
 

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -4,7 +4,7 @@ Pre-configured MCP server definitions for business APIs. Copy relevant configs t
 
 ```bash
 ../scripts/mcp-setup.sh   # Interactive setup
-```
+```text
 
 ## Available Configs
 

--- a/templates/README.md
+++ b/templates/README.md
@@ -10,7 +10,7 @@ cp -r templates/client-engagement/ ~/office/client-acme/
 
 # Create a quarterly close project
 cp -r templates/quarterly-close/ ~/office/q1-2026-close/
-```
+```text
 
 Then add the new project path to `projects.conf`.
 
@@ -30,6 +30,6 @@ Includes pre-configured `/loop` patterns for recurring client tasks:
 /loop 30m check invoices/ for new files and update payment log
 /loop 1h scan correspondence/ for unresolved action items
 /loop 4h draft weekly status report for client
-```
+```text
 
 See [client-engagement/README.md](client-engagement/README.md) for full setup instructions.

--- a/templates/client-engagement/CLAUDE.md
+++ b/templates/client-engagement/CLAUDE.md
@@ -29,7 +29,7 @@ Load these skills from the office-forge `.claude/skills/` directory:
 
 ## Recurring Tasks
 
-```
+```text
 /loop 30m check invoices/ for new files and update payment log
 /loop 1h scan correspondence/ for unresolved action items
 /loop 4h draft weekly status report for client

--- a/templates/client-engagement/README.md
+++ b/templates/client-engagement/README.md
@@ -14,7 +14,7 @@ echo "/home/user/office/client-acme" >> projects.conf
 
 # Start CC in the engagement context
 cd ~/office/client-acme/ && claude
-```
+```text
 
 ## Folder Structure
 
@@ -27,7 +27,7 @@ client-engagement/
 ├── invoices/              # Issued invoices and payment records
 ├── correspondence/        # Emails, meeting notes, client comms
 └── reports/               # Deliverables, status reports, analyses
-```
+```text
 
 ## MCP Servers Included
 
@@ -45,7 +45,7 @@ Once CC is open in this project, use `/loop` for automatic recurring tasks:
 /loop 30m check invoices/ for new files and log payment status
 /loop 1h summarize new correspondence and flag action items
 /loop 4h generate client status report from reports/ folder
-```
+```text
 
 ## Getting Started
 


### PR DESCRIPTION
## Summary
- Bump `lint-md-links.yml` `uses:` SHA pin to current `qte77/.github` main (2026-04-27, includes #20 schedule-skip-md and #21 cli2 docs)
- Apply markdown inference fixes for canonical lint compliance (where applicable):
  - MD040 (fence language) inferred from block content (bash/python/json/yaml/text)
  - MD041 (first-line H1) inferred from filename
  - MD025 (multiple H1s) demoted to H2
  - MD036 (emphasis-as-heading) converted to H3

Generated with Claude <noreply@anthropic.com>